### PR TITLE
Enabling the use of arguments

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ import os
 from urllib.parse import urljoin
 
 import panel as pn
-from bokeh.embed import server_session
+from bokeh.embed import server_document, server_session
 from bokeh.util.token import generate_session_id
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.staticfiles import StaticFiles
@@ -38,9 +38,11 @@ async def panel_model(request: Request, model: str, user=Depends(auth_manager)):
     else:
         url = f"http://0.0.0.0:5006/panel/{model}"
 
-    script = server_session(
-        session_id=generate_session_id(SECRET_KEY, signed=True), url=url
-    )
+    # script = server_session(
+    #     session_id=generate_session_id(SECRET_KEY, signed=True), url=url
+    # )
+
+    script = server_document(url=url, arguments=request.query_params._dict)
 
     return templates.TemplateResponse(
         "panel_model.html",
@@ -62,6 +64,6 @@ pn.serve(
     show=False,
     sign_sessions=True,
     secret_key=SECRET_KEY,
-    generate_session_ids=False,
+    generate_session_ids=True,
     num_process=1 if os.name == "nt" else 2,
 )

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ import os
 from urllib.parse import urljoin
 
 import panel as pn
-from bokeh.embed import server_document, server_session
+from bokeh.embed import server_document
 from bokeh.util.token import generate_session_id
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.staticfiles import StaticFiles

--- a/app/main.py
+++ b/app/main.py
@@ -38,11 +38,10 @@ async def panel_model(request: Request, model: str, user=Depends(auth_manager)):
     else:
         url = f"http://0.0.0.0:5006/panel/{model}"
 
-    # script = server_session(
-    #     session_id=generate_session_id(SECRET_KEY, signed=True), url=url
-    # )
-
-    script = server_document(url=url, arguments=request.query_params._dict)
+    headers = {"Bokeh-Session-Id": generate_session_id(SECRET_KEY, signed=True)}
+    script = server_document(
+        url=url, arguments=request.query_params._dict, headers=headers
+    )
 
     return templates.TemplateResponse(
         "panel_model.html",
@@ -64,6 +63,6 @@ pn.serve(
     show=False,
     sign_sessions=True,
     secret_key=SECRET_KEY,
-    generate_session_ids=True,
+    generate_session_ids=False,
     num_process=1 if os.name == "nt" else 2,
 )

--- a/app/main.py
+++ b/app/main.py
@@ -38,9 +38,9 @@ async def panel_model(request: Request, model: str, user=Depends(auth_manager)):
     else:
         url = f"http://0.0.0.0:5006/panel/{model}"
 
-    headers = {"Bokeh-Session-Id": generate_session_id(SECRET_KEY, signed=True)}
+    headers = {"bokeh-session-id": generate_session_id(SECRET_KEY, signed=True)}
     script = server_document(
-        url=url, arguments=request.query_params._dict, headers=headers
+        url=url, arguments=dict(request.query_params), headers=headers
     )
 
     return templates.TemplateResponse(

--- a/app/main.py
+++ b/app/main.py
@@ -34,7 +34,7 @@ async def panel_model(request: Request, model: str, user=Depends(auth_manager)):
         raise HTTPException(status_code=404, detail="Item not found")
 
     if os.getenv("DOCKERENV"):
-        url = urljoin(request.headers["Referer"], f"panel/{model}")
+        url = urljoin(request.headers["host"], f"panel/{model}")
     else:
         url = f"http://0.0.0.0:5006/panel/{model}"
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,3 +5,6 @@ dependencies:
   - flake8
   - isort
   - mypy
+  - requests
+  - pytest
+  - types-requests

--- a/models/button_click.py
+++ b/models/button_click.py
@@ -6,6 +6,7 @@ class ButtonClick(pn.viewable.Viewer):
     def __init__(self, **params):
         self.button = pn.widgets.Button(name="Click")
         super().__init__(**params)
+        pn.state.location.sync(self.button, {"clicks": "clicks"})
 
     @param.depends("button.clicks")
     def _update_button_click(self):

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -16,7 +16,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_http_version 1.1;
         proxy_buffering off;
     }
@@ -28,7 +28,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_http_version 1.1;
         proxy_buffering off;
     }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,61 @@
+from urllib.parse import urljoin
+
+import pytest
+import requests
+from bokeh.util.token import generate_session_id
+
+from app.auth import auth_manager
+from app.settings import SECRET_KEY
+from models import titles
+
+
+@pytest.mark.parametrize("model", list(titles))
+@pytest.mark.parametrize(
+    "baseurl,env",
+    [("http://0.0.0.0:5006", "local"), ("http://0.0.0.0:8080", "docker")],
+)
+def test_bokeh_auth(model, baseurl, env):
+    # Check if live
+    try:
+        response = requests.get(baseurl)
+    except requests.exceptions.ConnectionError:
+        pytest.skip(f"{env} webpage is not live. Skipping.")
+
+    url = urljoin(baseurl, f"panel/{model}")
+
+    # Without permission
+    response = requests.get(url)
+    assert response.status_code == 403
+
+    # With permission
+    headers = {"bokeh-session-id": generate_session_id(SECRET_KEY, signed=True)}
+    response = requests.get(url, headers=headers)
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize("model", list(titles))
+@pytest.mark.parametrize(
+    "baseurl,env",
+    [("http://0.0.0.0:8000", "local"), ("http://0.0.0.0:8080", "docker")],
+)
+def test_fastapi_auth(model, baseurl, env):
+    # Check if live
+    try:
+        response = requests.get(baseurl)
+    except requests.exceptions.ConnectionError:
+        pytest.skip(f"{env} webpage is not live. Skipping.")
+
+    url = urljoin(baseurl, model)
+    redirect_url = urljoin(baseurl, f"/login?next=/{model}")
+
+    # Without permission
+    response = requests.get(url)
+    assert response.status_code == 200
+    assert response.url == redirect_url
+
+    # With permission
+    cookies = {"access-token": auth_manager.create_access_token(data={"sub": "test"})}
+    response = requests.get(url, cookies=cookies)
+    assert response.status_code == 200
+    assert response.url == url
+    assert "/autoload.js?bokeh-autoload-element" in response.text


### PR DESCRIPTION
Fixes #2

Example of how to pass arguments to panel apps. 

<strike>With the current implementation it does not lock the panel models behind the login screen and do not work with docker.</strike>

Video of the implementation:

https://user-images.githubusercontent.com/19758978/154704138-db419e0c-d192-44d4-bbeb-a1e13c40c6bf.mp4


References:
https://github.com/bokeh/bokeh/issues/10661
 